### PR TITLE
Renamed 'hierarchyWindowChanged' to 'hierarchyChanged'.

### DIFF
--- a/Core/Util/Editor/EditorApplicationUtil.cs
+++ b/Core/Util/Editor/EditorApplicationUtil.cs
@@ -27,13 +27,13 @@ namespace DTValidator.Internal {
 		public static Action SceneDirtied = delegate { };
 
 		static EditorApplicationUtil() {
-			EditorApplication.hierarchyWindowChanged += HierarchyWindowChanged;
+			EditorApplication.hierarchyChanged += HierarchyChanged;
 			SceneView.onSceneGUIDelegate += OnSceneGUI;
 			Undo.postprocessModifications += PostProcessModifications;
 		}
 
 		private static int previousObjectCount_ = 0;
-		private static void HierarchyWindowChanged() {
+		private static void HierarchyChanged() {
 			int newObjectCount = GameObject.FindObjectsOfType<UnityEngine.Object>().Length;
 			if (newObjectCount != previousObjectCount_) {
 				previousObjectCount_ = newObjectCount;

--- a/Core/Util/Editor/EditorApplicationUtil.cs
+++ b/Core/Util/Editor/EditorApplicationUtil.cs
@@ -27,8 +27,14 @@ namespace DTValidator.Internal {
 		public static Action SceneDirtied = delegate { };
 
 		static EditorApplicationUtil() {
-			EditorApplication.hierarchyChanged += HierarchyChanged;
-			SceneView.onSceneGUIDelegate += OnSceneGUI;
+
+            #if UNITY_2018_1_OR_NEWER
+                EditorApplication.hierarchyChanged += HierarchyChanged;
+            #else
+                EditorApplication.hierarchyWindowChanged += HierarchyChanged;
+            #endif
+
+            SceneView.onSceneGUIDelegate += OnSceneGUI;
 			Undo.postprocessModifications += PostProcessModifications;
 		}
 


### PR DESCRIPTION
Also renamed the DTValidtor method 'HierarchWindowChanged' to 'HierarchyChanged' to avoid confusion between UnityEditor API and DTValidator.

Will close issue #6 