### PR TITLE
Added handling of dirty scenes in batchmode

### DIFF
--- a/Validation/Editor/ValidationUtil.cs
+++ b/Validation/Editor/ValidationUtil.cs
@@ -1,13 +1,8 @@
 #if UNITY_EDITOR
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using UnityEngine;
-using UnityEngine.Events;
-
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine.SceneManagement;
@@ -84,7 +79,7 @@ namespace DTValidator {
 
 		public static bool HasToPersistScene()
 		{
-			if (UnityEditorInternal.InternalEditorUtility.inBatchMode)
+			if (Application.isBatchMode)
 			{
 				EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
 				return false;

--- a/Validation/Editor/ValidationUtil.cs
+++ b/Validation/Editor/ValidationUtil.cs
@@ -46,8 +46,10 @@ namespace DTValidator {
 			return validationErrors;
 		}
 
-		public static IList<IValidationError> ValidateAllGameObjectsInSavedScenes(bool earlyExitOnError = false) {
-			if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo()) {
+		public static IList<IValidationError> ValidateAllGameObjectsInSavedScenes(bool earlyExitOnError = false)
+		{
+			if (HasToPersistScene())
+			{
 				return null;
 			}
 
@@ -56,8 +58,10 @@ namespace DTValidator {
 			});
 		}
 
-		public static IList<IValidationError> ValidateAllGameObjectsInOpenScenes(bool earlyExitOnError = false) {
-			if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo()) {
+		public static IList<IValidationError> ValidateAllGameObjectsInOpenScenes(bool earlyExitOnError = false)
+		{
+			if (HasToPersistScene())
+			{
 				return null;
 			}
 
@@ -66,8 +70,10 @@ namespace DTValidator {
 			});
 		}
 
-		public static IList<IValidationError> ValidateAllGameObjectsInBuildSettingScenes(bool earlyExitOnError = false) {
-			if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo()) {
+		public static IList<IValidationError> ValidateAllGameObjectsInBuildSettingScenes(bool earlyExitOnError = false)
+		{
+			if (HasToPersistScene())
+			{
 				return null;
 			}
 
@@ -76,7 +82,19 @@ namespace DTValidator {
 			});
 		}
 
-		public static IList<IValidationError> ValidateAllGameObjectsInScenes(IEnumerable<Scene> scenes, bool earlyExitOnError = false) {
+		public static bool HasToPersistScene()
+		{
+			if (UnityEditorInternal.InternalEditorUtility.inBatchMode)
+			{
+				EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+				return false;
+			}
+
+			return !EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo();
+		}
+
+		public static IList<IValidationError> ValidateAllGameObjectsInScenes(IEnumerable<Scene> scenes, bool earlyExitOnError = false)
+		{
 			List<IValidationError> validationErrors = new List<IValidationError>();
 
 			foreach (Scene scene in scenes) {


### PR DESCRIPTION
There are cases where, if in Batchmode, showing the dialog for saving a scene will break the test (as there is no UI). 
Checking if it's in batchmode, and forcing a new, clean scene, to be opened, fixes this problems