### PR TITLE
The method signature of RegisterVoidListener has changed.

### DIFF
--- a/Core/Extensions/UnityEventReflectionExtensions.cs
+++ b/Core/Extensions/UnityEventReflectionExtensions.cs
@@ -18,7 +18,7 @@ namespace DTValidator.Internal {
 		public static void AddVoidPersistentListener(this UnityEventBase unityEvent, UnityEngine.Object targetObj, string methodName) {
 			var persistentCalls = kPersistentCallsField.GetValue(unityEvent);
 			kAddListenerMethod.Invoke(persistentCalls, null);
-			kRegisterVoidListenerMethod.Invoke(persistentCalls, new object[] { 0, targetObj, methodName });
+			kRegisterVoidListenerMethod.Invoke(persistentCalls, new object[] { 0, targetObj, typeof(UnityEngine.Object), methodName });
 			kDirtyPersistentCallsMethod.Invoke(unityEvent, null);
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/DarrenTsung/DTValidator/issues/16

However, maybe there is a way to avoid relying on these internals in the first place..